### PR TITLE
deprecate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# OpenTelemetry Lambda
+# OpenTelemetry Lambda - deprecated
 
-
-### [Design Proposal](docs/design_proposal.md)
-
-### [OpenTelemetry Collector extension](collector/README.md)
-
-### [OpenTelemetry Python Lambda support](python/README.md) 
-
-### [OpenTelemetry Java Lambda support](java/README.md)
-
-### [OpenTelemetry NodeJS Lambda support](nodejs/README.md)
-
-### [OpenTelemetry .Net Lambda support](dotnet/README.md)
+**This repository is deprecated and will be no longer supported. Please visit https://github.com/SumoLogic/sumologic-otel-lambda**


### PR DESCRIPTION
Deprecate repository. New lambda layers content in https://github.com/SumoLogic/sumologic-otel-lambda